### PR TITLE
Ignore ECONNRESET on connection close

### DIFF
--- a/src/events/ReconnectingWebSocket.mjs
+++ b/src/events/ReconnectingWebSocket.mjs
@@ -200,6 +200,11 @@ export default class ReconnectingWebSocket extends events.EventEmitter {
   close() {
     if (this._ws) {
       this._ws.removeAllListeners();
+
+      // ignore ECONNRESET errors
+      // https://github.com/websockets/ws/issues/1256
+      this._ws.on("error", () => {});
+
       this._ws.close();
       this._ws = null;
       this.emit("close");


### PR DESCRIPTION
ws@3.3.3 stopped swalling ECONNRESET inside the library upon a
connection close event. This commit swallows it when we know we are
attempting to disconnect.

Related to websockets/ws#1256.