### PR TITLE
Update to ws@5, remove now-unneeded event code

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "request": "^2.75.0",
     "request-promise-native": "^1.0.3",
     "retry": "^0.10.0",
-    "ws": "^4.0.0"
+    "ws": "^5.1.0"
   },
   "devDependencies": {
     "codecov": "^3.0.0",

--- a/src/events/ReconnectingWebSocket.mjs
+++ b/src/events/ReconnectingWebSocket.mjs
@@ -200,11 +200,6 @@ export default class ReconnectingWebSocket extends events.EventEmitter {
   close() {
     if (this._ws) {
       this._ws.removeAllListeners();
-
-      // ignore ECONNRESET errors
-      // https://github.com/websockets/ws/issues/1256
-      this._ws.on("error", () => {});
-
       this._ws.close();
       this._ws = null;
       this.emit("close");


### PR DESCRIPTION
When ws@4 was released, we had to put some code in the close() method of
the ReconnectingWebSocket to prevent error events from bubbling up
during the process of shutting down a websocket connection. In ws@5,
this is no longer necessary, as these events no longer occur.

This is a breaking change, see
https://github.com/websockets/ws/releases/tag/5.0.0 for the breaking
changes in the underlying `ws` library.

Closes #63.
Closes #64.