### PR TITLE
Update deps and remove deprecated api usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-config-prettier": "^3.1.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.9.0",
-    "eslint-plugin-node": "^7.0.1",
+    "eslint-plugin-node": "^8.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -1,4 +1,4 @@
-import url from "url";
+import { URL, URLSearchParams } from "url";
 import ARIWebSocket from "./ARIWebSocket";
 
 /**
@@ -40,15 +40,15 @@ export default class Events {
       wsOptions = {}
     } = params;
 
-    const parsedUrl = url.parse(userProvidedUrl);
+    const parsedUrl = new URL(userProvidedUrl);
 
-    parsedUrl.query = Object.assign({}, parsedUrl.query, {
-      api_key: `${username}:${password}`,
-      app: [].concat(app).join(","),
-      subscribeAll
-    });
+    const newSearchParams = new URLSearchParams(parsedUrl.searchParams);
+    newSearchParams.set("api_key", `${username}:${password}`);
+    newSearchParams.set("app", [].concat(app).join(","));
+    newSearchParams.set("subscribeAll", subscribeAll ? "true" : "false");
+    parsedUrl.search = newSearchParams.toString();
 
-    const wsUrl = url.format(parsedUrl);
+    const wsUrl = parsedUrl.href;
 
     return new ARIWebSocket({
       url: wsUrl,

--- a/test/events/index.spec.js
+++ b/test/events/index.spec.js
@@ -1,5 +1,4 @@
-import url from "url";
-import qs from "querystring";
+import { URL } from "url";
 import assert from "power-assert";
 import ws from "ws";
 import Events from "../../src/events";
@@ -29,9 +28,8 @@ describe("Events connect() returned emitter", () => {
 
       server.once("connection", (conn, req) => {
         emitter.once("open", () => {
-          const parts = url.parse(req.url);
-          const query = qs.parse(parts.query);
-          assert.equal(query.app, "myApp");
+          const parts = new URL(req.url, "ws://localhost:8088/");
+          assert.equal(parts.searchParams.get("app"), "myApp");
           done();
         });
       });
@@ -61,9 +59,8 @@ describe("Events connect() returned emitter", () => {
 
       server.once("connection", (conn, req) => {
         emitter.once("open", () => {
-          const parts = url.parse(req.url);
-          const query = qs.parse(parts.query);
-          assert.equal(query.app, "app1,app2,app3");
+          const parts = new URL(req.url, "ws://localhost:8088/");
+          assert.equal(parts.searchParams.get("app"), "app1,app2,app3");
           done();
         });
       });
@@ -93,9 +90,8 @@ describe("Events connect() returned emitter", () => {
 
       server.once("connection", (conn, req) => {
         emitter.once("open", () => {
-          const parts = url.parse(req.url);
-          const query = qs.parse(parts.query);
-          assert.equal(query.api_key, "foo:bar");
+          const parts = new URL(req.url, "ws://localhost:8088/");
+          assert.equal(parts.searchParams.get("api_key"), "foo:bar");
           done();
         });
       });
@@ -111,9 +107,8 @@ describe("Events connect() returned emitter", () => {
 
       server.once("connection", (conn, req) => {
         emitter.once("open", () => {
-          const parts = url.parse(req.url);
-          const query = qs.parse(parts.query);
-          assert.equal(query.subscribeAll, "true");
+          const parts = new URL(req.url, "ws://localhost:8088/");
+          assert.equal(parts.searchParams.get("subscribeAll"), "true");
           done();
         });
       });
@@ -130,9 +125,8 @@ describe("Events connect() returned emitter", () => {
 
       server.once("connection", (conn, req) => {
         emitter.once("open", () => {
-          const parts = url.parse(req.url);
-          const query = qs.parse(parts.query);
-          assert.equal(query.subscribeAll, "false");
+          const parts = new URL(req.url, "ws://localhost:8088/");
+          assert.equal(parts.searchParams.get("subscribeAll"), "false");
           done();
         });
       });


### PR DESCRIPTION
update eslint-plugin-node to v8
update eslint-plugin-prettier to v3

eslint-plugin-node@8 began throwing errors for usages of url.parse() so
this patch also addresses that. The suggested api `url.URL()` is also
available as far back as Node v6 so this change is a patch version bump.

Closes #100.