### PR TITLE
Migrate from request to axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,9 @@
     "temp-directory": "coverage/.nyc_output"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "debug": "^4.0.1",
     "esm": "^3.2.22",
-    "request": "^2.75.0",
-    "request-promise-native": "^1.0.3",
     "retry": "^0.12.0",
     "ws": "^7.2.5"
   },

--- a/src/api/ApplicationsAPI.js
+++ b/src/api/ApplicationsAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with ARI Stasis Applications.
@@ -21,9 +21,8 @@ export default class ApplicationsAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -38,7 +37,7 @@ export default class ApplicationsAPI {
   list() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/applications`,
+      url: `${this._baseUrl}/applications`,
     });
   }
 
@@ -60,7 +59,7 @@ export default class ApplicationsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/applications/${app}`,
+      url: `${this._baseUrl}/applications/${app}`,
     });
   }
 
@@ -92,8 +91,8 @@ export default class ApplicationsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/applications/${app}/subscription`,
-      qs: { eventSource: [].concat(eventSource).join(",") },
+      url: `${this._baseUrl}/applications/${app}/subscription`,
+      params: { eventSource: [].concat(eventSource).join(",") },
     });
   }
 
@@ -120,8 +119,8 @@ export default class ApplicationsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/applications/${app}/subscription`,
-      qs: { eventSource: [].concat(eventSource).join(",") },
+      url: `${this._baseUrl}/applications/${app}/subscription`,
+      params: { eventSource: [].concat(eventSource).join(",") },
     });
   }
 
@@ -147,8 +146,8 @@ export default class ApplicationsAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/applications/${app}/eventFilter`,
-      body: { filter },
+      url: `${this._baseUrl}/applications/${app}/eventFilter`,
+      data: { filter },
     });
   }
 }

--- a/src/api/AsteriskAPI.js
+++ b/src/api/AsteriskAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk variables, modules,
@@ -22,9 +22,8 @@ export default class AsteriskAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -53,7 +52,7 @@ export default class AsteriskAPI {
     // prettier-ignore
     return this._request({
       method: 'GET',
-      uri: `${this._baseUrl}/asterisk/config/dynamic/${configClass}/${objectType}/${id}`
+      url: `${this._baseUrl}/asterisk/config/dynamic/${configClass}/${objectType}/${id}`
     });
   }
 
@@ -87,8 +86,8 @@ export default class AsteriskAPI {
     // prettier-ignore
     return this._request({
       method: 'PUT',
-      uri: `${this._baseUrl}/asterisk/config/dynamic/${configClass}/${objectType}/${id}`,
-      body: { fields }
+      url: `${this._baseUrl}/asterisk/config/dynamic/${configClass}/${objectType}/${id}`,
+      data: { fields }
     });
   }
 
@@ -118,7 +117,7 @@ export default class AsteriskAPI {
     // prettier-ignore
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/asterisk/config/dynamic/${configClass}/${objectType}/${id}`
+      url: `${this._baseUrl}/asterisk/config/dynamic/${configClass}/${objectType}/${id}`
     });
   }
 
@@ -139,8 +138,8 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/asterisk/info`,
-      qs: { only: [].concat(only).join(",") },
+      url: `${this._baseUrl}/asterisk/info`,
+      params: { only: [].concat(only).join(",") },
     });
   }
 
@@ -157,7 +156,7 @@ export default class AsteriskAPI {
   listModules() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/asterisk/modules`,
+      url: `${this._baseUrl}/asterisk/modules`,
     });
   }
 
@@ -180,7 +179,7 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/asterisk/modules/${name}`,
+      url: `${this._baseUrl}/asterisk/modules/${name}`,
     });
   }
 
@@ -202,7 +201,7 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/asterisk/modules/${name}`,
+      url: `${this._baseUrl}/asterisk/modules/${name}`,
     });
   }
 
@@ -225,7 +224,7 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/asterisk/modules/${name}`,
+      url: `${this._baseUrl}/asterisk/modules/${name}`,
     });
   }
 
@@ -248,7 +247,7 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/asterisk/modules/${name}`,
+      url: `${this._baseUrl}/asterisk/modules/${name}`,
     });
   }
 
@@ -265,7 +264,7 @@ export default class AsteriskAPI {
   listLogChannels() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/asterisk/logging`,
+      url: `${this._baseUrl}/asterisk/logging`,
     });
   }
 
@@ -289,8 +288,8 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/asterisk/logging/${name}`,
-      qs: { configuration },
+      url: `${this._baseUrl}/asterisk/logging/${name}`,
+      params: { configuration },
     });
   }
 
@@ -312,7 +311,7 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/asterisk/logging/${name}`,
+      url: `${this._baseUrl}/asterisk/logging/${name}`,
     });
   }
 
@@ -334,7 +333,7 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/asterisk/logging/${name}/rotate`,
+      url: `${this._baseUrl}/asterisk/logging/${name}/rotate`,
     });
   }
 
@@ -355,8 +354,8 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/asterisk/variable`,
-      qs: { variable },
+      url: `${this._baseUrl}/asterisk/variable`,
+      params: { variable },
     });
   }
 
@@ -377,8 +376,8 @@ export default class AsteriskAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/asterisk/variable`,
-      qs: { variable, value },
+      url: `${this._baseUrl}/asterisk/variable`,
+      params: { variable, value },
     });
   }
 }

--- a/src/api/BridgesAPI.js
+++ b/src/api/BridgesAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk Bridges and the channels
@@ -22,9 +22,8 @@ export default class BridgesAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -39,7 +38,7 @@ export default class BridgesAPI {
   list() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/bridges`,
+      url: `${this._baseUrl}/bridges`,
     });
   }
 
@@ -66,8 +65,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges`,
-      qs: {
+      url: `${this._baseUrl}/bridges`,
+      params: {
         name,
         bridgeId,
         type: [].concat(type).join(","),
@@ -100,8 +99,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}`,
-      qs: {
+      url: `${this._baseUrl}/bridges/${id}`,
+      params: {
         name,
         type: [].concat(type).join(","),
       },
@@ -125,7 +124,7 @@ export default class BridgesAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/bridges/${id}`,
+      url: `${this._baseUrl}/bridges/${id}`,
     });
   }
 
@@ -146,7 +145,7 @@ export default class BridgesAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/bridges/${id}`,
+      url: `${this._baseUrl}/bridges/${id}`,
     });
   }
 
@@ -174,8 +173,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}/addChannel`,
-      qs: {
+      url: `${this._baseUrl}/bridges/${id}/addChannel`,
+      params: {
         channel: [].concat(channel).join(","),
         role,
       },
@@ -204,8 +203,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}/removeChannel`,
-      qs: { channel: [].concat(channel).join(",") },
+      url: `${this._baseUrl}/bridges/${id}/removeChannel`,
+      params: { channel: [].concat(channel).join(",") },
     });
   }
 
@@ -229,8 +228,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}/moh`,
-      qs: { mohClass },
+      url: `${this._baseUrl}/bridges/${id}/moh`,
+      params: { mohClass },
     });
   }
 
@@ -253,7 +252,7 @@ export default class BridgesAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/bridges/${id}/moh`,
+      url: `${this._baseUrl}/bridges/${id}/moh`,
     });
   }
 
@@ -299,8 +298,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}/play`,
-      qs: {
+      url: `${this._baseUrl}/bridges/${id}/play`,
+      params: {
         media: [].concat(media).join(","),
         lang,
         offsetms,
@@ -353,8 +352,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}/play/${playId}`,
-      qs: {
+      url: `${this._baseUrl}/bridges/${id}/play/${playId}`,
+      params: {
         media: [].concat(media).join(","),
         lang,
         offsetms,
@@ -406,8 +405,8 @@ export default class BridgesAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/bridges/${id}/record`,
-      qs: {
+      url: `${this._baseUrl}/bridges/${id}/record`,
+      params: {
         name,
         format,
         maxDurationSeconds,

--- a/src/api/ChannelsAPI.js
+++ b/src/api/ChannelsAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk Channels.
@@ -21,9 +21,8 @@ export default class ChannelsAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -38,7 +37,7 @@ export default class ChannelsAPI {
   list() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/channels`,
+      url: `${this._baseUrl}/channels`,
     });
   }
 
@@ -109,8 +108,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels`,
-      qs: {
+      url: `${this._baseUrl}/channels`,
+      params: {
         endpoint,
         extension,
         context,
@@ -125,7 +124,7 @@ export default class ChannelsAPI {
         originator,
         formats: [].concat(formats).join(","),
       },
-      body: { variables },
+      data: { variables },
     });
   }
 
@@ -169,8 +168,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/create`,
-      qs: {
+      url: `${this._baseUrl}/channels/create`,
+      params: {
         endpoint,
         app,
         appArgs,
@@ -199,7 +198,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/channels/${id}`,
+      url: `${this._baseUrl}/channels/${id}`,
     });
   }
 
@@ -273,8 +272,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}`,
-      qs: {
+      url: `${this._baseUrl}/channels/${id}`,
+      params: {
         endpoint,
         extension,
         context,
@@ -288,7 +287,7 @@ export default class ChannelsAPI {
         originator,
         formats: [].concat(formats).join(","),
       },
-      body: { variables },
+      data: { variables },
     });
   }
 
@@ -311,8 +310,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/channels/${id}`,
-      qs: { reason },
+      url: `${this._baseUrl}/channels/${id}`,
+      params: { reason },
     });
   }
 
@@ -339,8 +338,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/continue`,
-      qs: { context, extension, priority, label },
+      url: `${this._baseUrl}/channels/${id}/continue`,
+      params: { context, extension, priority, label },
     });
   }
 
@@ -366,8 +365,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/redirect`,
-      qs: { endpoint },
+      url: `${this._baseUrl}/channels/${id}/redirect`,
+      params: { endpoint },
     });
   }
 
@@ -388,7 +387,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/answer`,
+      url: `${this._baseUrl}/channels/${id}/answer`,
     });
   }
 
@@ -410,7 +409,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/ring`,
+      url: `${this._baseUrl}/channels/${id}/ring`,
     });
   }
 
@@ -432,7 +431,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/channels/${id}/ring`,
+      url: `${this._baseUrl}/channels/${id}/ring`,
     });
   }
 
@@ -470,8 +469,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/dtmf`,
-      qs: { dtmf, before, between, duration, after },
+      url: `${this._baseUrl}/channels/${id}/dtmf`,
+      params: { dtmf, before, between, duration, after },
     });
   }
 
@@ -494,8 +493,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/mute`,
-      qs: { direction },
+      url: `${this._baseUrl}/channels/${id}/mute`,
+      params: { direction },
     });
   }
 
@@ -518,8 +517,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/channels/${id}/mute`,
-      qs: { direction },
+      url: `${this._baseUrl}/channels/${id}/mute`,
+      params: { direction },
     });
   }
 
@@ -540,7 +539,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/hold`,
+      url: `${this._baseUrl}/channels/${id}/hold`,
     });
   }
 
@@ -561,7 +560,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/channels/${id}/hold`,
+      url: `${this._baseUrl}/channels/${id}/hold`,
     });
   }
 
@@ -587,8 +586,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/moh`,
-      qs: { mohClass },
+      url: `${this._baseUrl}/channels/${id}/moh`,
+      params: { mohClass },
     });
   }
 
@@ -609,7 +608,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/channels/${id}/moh`,
+      url: `${this._baseUrl}/channels/${id}/moh`,
     });
   }
 
@@ -632,7 +631,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/silence`,
+      url: `${this._baseUrl}/channels/${id}/silence`,
     });
   }
 
@@ -654,7 +653,7 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/channels/${id}/silence`,
+      url: `${this._baseUrl}/channels/${id}/silence`,
     });
   }
 
@@ -696,8 +695,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/play`,
-      qs: {
+      url: `${this._baseUrl}/channels/${id}/play`,
+      params: {
         media: [].concat(media).join(","),
         lang,
         offsetms,
@@ -748,8 +747,8 @@ export default class ChannelsAPI {
     const playId = encodeURIComponent(playbackId);
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/play/${playId}`,
-      qs: {
+      url: `${this._baseUrl}/channels/${id}/play/${playId}`,
+      params: {
         media: [].concat(media).join(","),
         lang,
         offsetms,
@@ -803,8 +802,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/record`,
-      qs: {
+      url: `${this._baseUrl}/channels/${id}/record`,
+      params: {
         name,
         format,
         maxDurationSeconds,
@@ -836,8 +835,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/channels/${id}/variable`,
-      qs: { variable },
+      url: `${this._baseUrl}/channels/${id}/variable`,
+      params: { variable },
     });
   }
 
@@ -862,8 +861,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/variable`,
-      qs: { variable, value },
+      url: `${this._baseUrl}/channels/${id}/variable`,
+      params: { variable, value },
     });
   }
 
@@ -901,8 +900,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/snoop`,
-      qs: { app, spy, whisper, appArgs, snoopId },
+      url: `${this._baseUrl}/channels/${id}/snoop`,
+      params: { app, spy, whisper, appArgs, snoopId },
     });
   }
 
@@ -942,8 +941,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/snoop/${sid}`,
-      qs: { app, spy, whisper, appArgs },
+      url: `${this._baseUrl}/channels/${id}/snoop/${sid}`,
+      params: { app, spy, whisper, appArgs },
     });
   }
 
@@ -968,8 +967,8 @@ export default class ChannelsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/channels/${id}/dial`,
-      qs: { caller, timeout },
+      url: `${this._baseUrl}/channels/${id}/dial`,
+      params: { caller, timeout },
     });
   }
 }

--- a/src/api/DeviceStatesAPI.js
+++ b/src/api/DeviceStatesAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with device states controlled by ARI.
@@ -21,9 +21,8 @@ export default class DeviceStatesAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -38,7 +37,7 @@ export default class DeviceStatesAPI {
   list() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/deviceStates`,
+      url: `${this._baseUrl}/deviceStates`,
     });
   }
 
@@ -59,7 +58,7 @@ export default class DeviceStatesAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/deviceStates/${name}`,
+      url: `${this._baseUrl}/deviceStates/${name}`,
     });
   }
 
@@ -86,8 +85,8 @@ export default class DeviceStatesAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/deviceStates/${name}`,
-      qs: { deviceState },
+      url: `${this._baseUrl}/deviceStates/${name}`,
+      params: { deviceState },
     });
   }
 
@@ -110,7 +109,7 @@ export default class DeviceStatesAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/deviceStates/${name}`,
+      url: `${this._baseUrl}/deviceStates/${name}`,
     });
   }
 }

--- a/src/api/EndpointsAPI.js
+++ b/src/api/EndpointsAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk endpoints.
@@ -21,9 +21,8 @@ export default class EndpointsAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -37,7 +36,7 @@ export default class EndpointsAPI {
   list() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/endpoints`,
+      url: `${this._baseUrl}/endpoints`,
     });
   }
 
@@ -67,9 +66,9 @@ export default class EndpointsAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/endpoints/sendMessage`,
-      qs: { to, from, body },
-      body: { variables },
+      url: `${this._baseUrl}/endpoints/sendMessage`,
+      params: { to, from, body },
+      data: { variables },
     });
   }
 
@@ -90,7 +89,7 @@ export default class EndpointsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/endpoints/${tech}`,
+      url: `${this._baseUrl}/endpoints/${tech}`,
     });
   }
 
@@ -115,7 +114,7 @@ export default class EndpointsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/endpoints/${tech}/${res}`,
+      url: `${this._baseUrl}/endpoints/${tech}/${res}`,
     });
   }
 
@@ -148,9 +147,9 @@ export default class EndpointsAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/endpoints/${tech}/${res}/sendMessage`,
-      qs: { from, body },
-      body: { variables },
+      url: `${this._baseUrl}/endpoints/${tech}/${res}/sendMessage`,
+      params: { from, body },
+      data: { variables },
     });
   }
 }

--- a/src/api/EventsAPI.js
+++ b/src/api/EventsAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for creating an Asterisk user event.
@@ -21,9 +21,8 @@ export default class EventsAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -55,12 +54,12 @@ export default class EventsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/events/user/${evt}`,
-      qs: {
+      url: `${this._baseUrl}/events/user/${evt}`,
+      params: {
         application,
         source: [].concat(source).join(","),
       },
-      body: { variables },
+      data: { variables },
     });
   }
 }

--- a/src/api/MailboxesAPI.js
+++ b/src/api/MailboxesAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk mailboxes.
@@ -23,9 +23,8 @@ export default class MailboxesAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -42,7 +41,7 @@ export default class MailboxesAPI {
   list() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/mailboxes`,
+      url: `${this._baseUrl}/mailboxes`,
     });
   }
 
@@ -65,7 +64,7 @@ export default class MailboxesAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/mailboxes/${name}`,
+      url: `${this._baseUrl}/mailboxes/${name}`,
     });
   }
 
@@ -89,8 +88,8 @@ export default class MailboxesAPI {
 
     return this._request({
       method: "PUT",
-      uri: `${this._baseUrl}/mailboxes/${name}`,
-      qs: { oldMessages, newMessages },
+      url: `${this._baseUrl}/mailboxes/${name}`,
+      params: { oldMessages, newMessages },
     });
   }
 
@@ -112,7 +111,7 @@ export default class MailboxesAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/mailboxes/${name}`,
+      url: `${this._baseUrl}/mailboxes/${name}`,
     });
   }
 }

--- a/src/api/PlaybacksAPI.js
+++ b/src/api/PlaybacksAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk playbacks.
@@ -21,9 +21,8 @@ export default class PlaybacksAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -44,7 +43,7 @@ export default class PlaybacksAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/playbacks/${id}`,
+      url: `${this._baseUrl}/playbacks/${id}`,
     });
   }
 
@@ -65,7 +64,7 @@ export default class PlaybacksAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/playbacks/${id}`,
+      url: `${this._baseUrl}/playbacks/${id}`,
     });
   }
 
@@ -90,8 +89,8 @@ export default class PlaybacksAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/playbacks/${id}/control`,
-      qs: { operation },
+      url: `${this._baseUrl}/playbacks/${id}/control`,
+      params: { operation },
     });
   }
 }

--- a/src/api/RecordingsAPI.js
+++ b/src/api/RecordingsAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with both live and stored recordings.
@@ -21,9 +21,8 @@ export default class RecordingsAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -37,7 +36,7 @@ export default class RecordingsAPI {
   listStored() {
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/recordings/stored`,
+      url: `${this._baseUrl}/recordings/stored`,
     });
   }
 
@@ -58,7 +57,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/recordings/stored/${name}`,
+      url: `${this._baseUrl}/recordings/stored/${name}`,
     });
   }
 
@@ -79,7 +78,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/recordings/stored/${name}`,
+      url: `${this._baseUrl}/recordings/stored/${name}`,
     });
   }
 
@@ -102,7 +101,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/recordings/stored/${name}/file`,
+      url: `${this._baseUrl}/recordings/stored/${name}/file`,
     });
   }
 
@@ -129,8 +128,8 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/recordings/stored/${name}/copy`,
-      qs: { destinationRecordingName },
+      url: `${this._baseUrl}/recordings/stored/${name}/copy`,
+      params: { destinationRecordingName },
     });
   }
 
@@ -152,7 +151,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/recordings/live/${name}`,
+      url: `${this._baseUrl}/recordings/live/${name}`,
     });
   }
 
@@ -173,7 +172,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/recordings/live/${name}`,
+      url: `${this._baseUrl}/recordings/live/${name}`,
     });
   }
 
@@ -194,7 +193,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/recordings/live/${name}/stop`,
+      url: `${this._baseUrl}/recordings/live/${name}/stop`,
     });
   }
 
@@ -218,7 +217,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/recordings/live/${name}/pause`,
+      url: `${this._baseUrl}/recordings/live/${name}/pause`,
     });
   }
 
@@ -240,7 +239,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/recordings/live/${name}/pause`,
+      url: `${this._baseUrl}/recordings/live/${name}/pause`,
     });
   }
 
@@ -263,7 +262,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "POST",
-      uri: `${this._baseUrl}/recordings/live/${name}/mute`,
+      url: `${this._baseUrl}/recordings/live/${name}/mute`,
     });
   }
 
@@ -285,7 +284,7 @@ export default class RecordingsAPI {
 
     return this._request({
       method: "DELETE",
-      uri: `${this._baseUrl}/recordings/live/${name}/mute`,
+      url: `${this._baseUrl}/recordings/live/${name}/mute`,
     });
   }
 }

--- a/src/api/SoundsAPI.js
+++ b/src/api/SoundsAPI.js
@@ -1,4 +1,4 @@
-import rp from "request-promise-native";
+import axios from "axios";
 
 /**
  * REST API Resource for interacting with Asterisk sounds.
@@ -21,9 +21,8 @@ export default class SoundsAPI {
     this._baseUrl = params.baseUrl;
 
     /** @private */
-    this._request = rp.defaults({
+    this._request = axios.create({
       auth: { username, password },
-      json: true,
     });
   }
 
@@ -43,8 +42,8 @@ export default class SoundsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/sounds`,
-      qs: { lang, format },
+      url: `${this._baseUrl}/sounds`,
+      params: { lang, format },
     });
   }
 
@@ -64,7 +63,7 @@ export default class SoundsAPI {
 
     return this._request({
       method: "GET",
-      uri: `${this._baseUrl}/sounds/${id}`,
+      url: `${this._baseUrl}/sounds/${id}`,
     });
   }
 }


### PR DESCRIPTION
The request library has been marked as deprecated. This patch moves from
using request and request-promise-native to using axios.

Closes #131.