### PR TITLE
changed_link_api_doc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "marquee.widgets.npm-stats.packageNames": [
+        "awry"
+    ]
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -100,7 +100,7 @@ events.on(&apos;message&apos;, message =&gt; {
   console.log(message);
 });</code>
 </code></pre>
-<p>For more details see the <a href="http://chadmcelligott.com/awry">full API documentation</a>.</p>
+<p>For more details see the <a href="https://awry01.netlify.app/">full API documentation</a>.</p>
 <h3 id="debugging">debugging</h3><p>awry uses the <a href="https://github.com/visionmedia/debug">debug</a> module to log
 debugging output. To enable this output to print to the console, set the
 environment variable <code>DEBUG</code> to one of the following when running your app:</p>


### PR DESCRIPTION
link for full API documentation is leading to some false site in the awry npm package, so I changed the link to https://awry01.netlify.app/,a clone site which I deployed on netlify